### PR TITLE
Removing tmi auth

### DIFF
--- a/app/twitchWebsocket.js
+++ b/app/twitchWebsocket.js
@@ -47,18 +47,14 @@ const setLastPing = () => {
   lastPing = Math.floor(Date.now() / 1000);
 };
 
-const startChat = async (twitchChatAuth, debugFlag) => {
-  chatAuth = twitchChatAuth;
+const startChat = async (debugFlag) => {
   debug = debugFlag;
   ws = new WebSocket("wss://irc-ws.chat.twitch.tv:443");
   ws.on("open", () => {
-    if (!chatAuth.startsWith("oauth:")) {
-      chatAuth = `oauth:${chatAuth}`;
-    }
-    sendMessage(`PASS ${chatAuth}`);
-    // We don't actually need to send the correct
-    // username for the tmi oauth, just "something".
-    sendMessage(`NICK fakeuser`);
+    sendMessage(`PASS blahblahblah`);
+    sendMessage(
+      `NICK justinfan${Math.floor(100000 + Math.floor(Math.random() * 899999))}`
+    );
   });
 
   // TODO on WS Close - attempt to reconenct.
@@ -66,7 +62,7 @@ const startChat = async (twitchChatAuth, debugFlag) => {
     console.log("Disconnected from chat, reconnecting.");
     stopPingTimer();
     setTimeout(() => {
-      startChat(chatAuth, debug);
+      startChat(debug);
     }, 500);
   });
 

--- a/app/twitchWebsocket.js
+++ b/app/twitchWebsocket.js
@@ -1,8 +1,6 @@
 "use strict";
 const WebSocket = require("ws");
-let debug = false,
-  ws,
-  chatAuth,
+let ws,
   chatUser,
   pingTimer,
   listenForPingTimer,
@@ -47,8 +45,7 @@ const setLastPing = () => {
   lastPing = Math.floor(Date.now() / 1000);
 };
 
-const startChat = async (debugFlag) => {
-  debug = debugFlag;
+const startChat = async () => {
   ws = new WebSocket("wss://irc-ws.chat.twitch.tv:443");
   ws.on("open", () => {
     sendMessage(`PASS blahblahblah`);
@@ -62,7 +59,7 @@ const startChat = async (debugFlag) => {
     console.log("Disconnected from chat, reconnecting.");
     stopPingTimer();
     setTimeout(() => {
-      startChat(debug);
+      startChat();
     }, 500);
   });
 

--- a/index.js
+++ b/index.js
@@ -8,24 +8,16 @@ const webServer = require("./app/webserver");
 let debug = false, // Spits out debug Messsages
   port = 4521,
   Settings = {
-    // The default settings
-    twitchChatAuth: "", // Keep this out of the source
+    debug: false,
+    port: 4521,
+    sentry: "",
   };
 // Constants
 const settingsFileName = "./settings.json";
 
 // Entry Point for the application
 const entryPoint = async () => {
-  if (debug) process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; // Dev env doesn't like the twitch SSL Cert. I prob need to kick the cert package up the arse. But for deving I'm just bypassing the check :-P
   console.log("Twitch Mod Checker.");
-
-  // A simple sanity check...
-  if (Settings.twitchChatAuth) {
-    console.error(
-      "(ERROR) Do not put these values into the source. Why? Cause I don't want to accidently push them to the git."
-    );
-    process.exit(1);
-  }
 
   // Load the settings file into the var.
   if (!fs.existsSync(settingsFileName)) {
@@ -35,9 +27,8 @@ const entryPoint = async () => {
     saveSettings();
   }
 
-  var buffer = fs.readFileSync(settingsFileName);
   try {
-    Settings = JSON.parse(buffer);
+    Settings = JSON.parse(fs.readFileSync(settingsFileName));
   } catch (err) {
     console.error(
       `(ERROR) Unable to parse settings file. This is prob cause there is bad json in it. Check the file and relaunch.`
@@ -48,6 +39,8 @@ const entryPoint = async () => {
   if ("debug" in Settings && Settings.debug === "boolean") {
     debug = Settings.debug;
   }
+
+  if (debug) process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; // Dev env doesn't like the twitch SSL Cert. I prob need to kick the cert package up the arse. But for deving I'm just bypassing the check :-P
 
   if ("sentry" in Settings) {
     if (Settings.sentry && typeof Settings.sentry === "string") {
@@ -63,7 +56,7 @@ const entryPoint = async () => {
     port = Settings.port;
   }
 
-  twitchChat.startChat(debug);
+  twitchChat.startChat();
   await webServer.init("localhost", port).catch((error) => {
     console.error(error);
     process.exit(1);

--- a/index.js
+++ b/index.js
@@ -63,12 +63,7 @@ const entryPoint = async () => {
     port = Settings.port;
   }
 
-  if (!Settings.twitchChatAuth || typeof Settings.sentry !== "string") {
-    console.error(`(ERROR) twitchChatAuth missing from settings file.`);
-    process.exit(1);
-  }
-
-  twitchChat.startChat(Settings.twitchChatAuth, debug);
+  twitchChat.startChat(debug);
   await webServer.init("localhost", port).catch((error) => {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
Ripping out the TMI auth.

Using the justinfan{number} readonly "account" we can read the mod list without needing a auth token. So why use one if its not needed. :-)